### PR TITLE
Set and keep user params for API credentials and queries

### DIFF
--- a/news_signals/newsapi.py
+++ b/news_signals/newsapi.py
@@ -47,12 +47,18 @@ class TooManyRequestsError(Exception):
     pass
 
 
-def set_headers(app_id, app_key):
+def set_headers(app_id=None, app_key=None, token=None):
     """
     set global headers for newsapi requests
     """
-    HEADERS['X-AYLIEN-NewsAPI-Application-ID'] = app_id
-    HEADERS['X-AYLIEN-NewsAPI-Application-Key'] = app_key
+    if app_id is not None:
+        HEADERS['X-AYLIEN-NewsAPI-Application-ID'] = app_id
+
+    if app_key is not None:
+        HEADERS['X-AYLIEN-NewsAPI-Application-Key'] = app_key
+
+    if token is not None:
+        HEADERS['Authorization'] = "Bearer {}".format(token)
 
 
 @sleep_and_retry

--- a/news_signals/test_signals.py
+++ b/news_signals/test_signals.py
@@ -561,6 +561,15 @@ class TestAylienSignal(SignalTest):
 
         assert stories_endpoint_mock.params['per_page'] == 3
 
+        # test with sample_per_tick=False and num_stories=10
+        _ = signal.sample_stories_in_window(
+            start, end,
+            num_stories=3,
+            sample_per_tick=False
+        )
+
+        assert stories_endpoint_mock.params['per_page'] == 10
+
 
 class TestWikimediaSignal(SignalTest):
 

--- a/news_signals/test_signals.py
+++ b/news_signals/test_signals.py
@@ -535,12 +535,10 @@ class TestAylienSignal(SignalTest):
 
     def test_num_stories_parameter(self):
         # create a mock response
-        mock_response = {
-            'stories': [
-                {'title': 'title', 'body': 'body', 'published_at': '2021-08-02T01:05:00Z'}
-                for _ in range(5)
-            ]
-        }
+        mock_response = [
+            {'title': 'title', 'body': 'body', 'published_at': '2021-08-02T01:05:00Z'}
+            for _ in range(5)
+        ]
         stories_endpoint_mock = MockRequestsEndpoint(response=mock_response)
         signal = signals.AylienSignal(
             'test-signal',
@@ -564,7 +562,7 @@ class TestAylienSignal(SignalTest):
         # test with sample_per_tick=False and num_stories=10
         _ = signal.sample_stories_in_window(
             start, end,
-            num_stories=3,
+            num_stories=10,
             sample_per_tick=False
         )
 

--- a/news_signals/test_signals.py
+++ b/news_signals/test_signals.py
@@ -216,13 +216,19 @@ class MockWikidataClient:
 class MockRequestsEndpoint:
     def __init__(self, response):
         self.response = response
+        self.params = {}
+        self.headers = {}
+        self.url = ""
 
     def __call__(
         self,
-        url: str,
         params: dict={},
         headers: dict={},
-    ):        
+        url: str="",
+    ):
+        self.params = params
+        self.headers = headers
+        self.url = url
         return self.response
 
 
@@ -525,6 +531,36 @@ class TestAylienSignal(SignalTest):
                     assert 'date' in e
                     assert 'wiki_links' in e
         assert n > 0
+
+
+    def test_num_stories_parameter(self):
+        # create a mock response
+        mock_response = {
+            'stories': [
+                {'title': 'title', 'body': 'body', 'published_at': '2021-08-02T01:05:00Z'}
+                for _ in range(5)
+            ]
+        }
+        stories_endpoint_mock = MockRequestsEndpoint(response=mock_response)
+        signal = signals.AylienSignal(
+            'test-signal',
+            params={},
+            stories_endpoint=stories_endpoint_mock
+        )
+
+        # dates inside data range of test df
+        start = '2021-08-01'
+        end = '2021-08-05'
+
+        # test with sample_per_tick=True and num_stories=3
+        _ = signal.sample_stories_in_window(
+            start, end,
+            num_stories=3,
+            sample_per_tick=True
+        )
+
+        assert stories_endpoint_mock.params['per_page'] == 3
+
 
 class TestWikimediaSignal(SignalTest):
 


### PR DESCRIPTION
In this PR we:

- allow the user to set their Authorization bearer token in the newsapi request headers
- fix a bug where the requested `num_stories` is not preserved in all branches of `signals.sample_stories_in_window`
- allow arbitrary keyword arguments to be added to the request in `signals.make_query`